### PR TITLE
Update user agent to evade current UA being blocked

### DIFF
--- a/src/consts.py
+++ b/src/consts.py
@@ -2,4 +2,4 @@ from ankiutils.consts import get_consts
 
 consts = get_consts(__name__)
 
-USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"


### PR DESCRIPTION
After the recent events that have been being documented over on Reddit in regards to one of the copycat apps, I tried to help one person who [needed to recover data promptly](https://www.reddit.com/r/Anki/comments/1kvd3ub/ankipro_scammed_me_and_now_ill_fail_my_med_school/) but was running into an issue with HTTP errors.

After a bit of digging, it seemed as though the older user agent was getting blocked. After talking them through manually updating the UA the import worked without any 502s anymore (they mentioned there was a bunch of duplication and that image cards were missing, but I think that is probably an unrelated issue).

Updating to this user agent string will only be a temporary work around for now, but I have updated it to use one that is definitely currently working.

Long term, I'd imagine the best solution would be an option to specify a user agent in the config and add some instructions for the user on how they can find their browser's current user agent.